### PR TITLE
etcd grpc proxy

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -446,6 +446,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${src_dir}/kube-proxy.manifest" "${dst_dir}/"
   cp "${src_dir}/cluster-autoscaler.manifest" "${dst_dir}/"
   cp "${src_dir}/etcd.manifest" "${dst_dir}"
+  cp "${src_dir}/etcd-grpc-proxy.manifest" "${dst_dir}"
   cp "${src_dir}/kube-scheduler.manifest" "${dst_dir}"
   cp "${src_dir}/kube-apiserver.manifest" "${dst_dir}"
   cp "${src_dir}/abac-authz-policy.jsonl" "${dst_dir}"

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -413,6 +413,14 @@ function generate-etcd-cert() {
                     "server auth",
                     "client auth"
                 ]
+            },
+            "grpcproxy": {
+                "expiry": "43800h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
             }
         }
     }
@@ -466,6 +474,12 @@ EOF
       echo "Generate peer certificates..."
       echo '{"CN":"'${member_ip}'","hosts":[""],"key":{"algo":"ecdsa","size":256}}' \
        | ${CFSSL_BIN} gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=peer -hostname="${member_ip},127.0.0.1" - \
+       | ${CFSSLJSON_BIN} -bare "${prefix}"
+      ;;
+    grpcproxy)
+      echo "Generate grpc_proxy certificates..."
+      echo '{"CN":"","hosts":["*"],"key":{"algo":"ecdsa","size":256}}' \
+       | ${CFSSL_BIN} gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=grpcproxy - \
        | ${CFSSLJSON_BIN} -bare "${prefix}"
       ;;
     *)

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -45,6 +45,7 @@ APISERVERS_EXTRA_NUM=${APISERVERS_EXTRA_NUM:-0}
 APISERVER_DATAPARTITION_CONFIG=${APISERVER_DATAPARTITION_CONFIG:-"abcdefghijklmnopqrstuvwxyz"}
 WORKLOADCONTROLLER_EXTRA_NUM=${WORKLOADCONTROLLER_EXTRA_NUM:-0}
 ETCD_EXTRA_NUM=${ETCD_EXTRA_NUM:-0}
+START_ETCD_GRPC_PROXY=${START_ETCD_GRPC_PROXY:-false}
 #switch to enable/disable kube-controller-manager leader-elect: --leader-elect=true/false
 ENABLE_KCM_LEADER_ELECT=${ENABLE_KCM_LEADER_ELECT:-true}
 #switch to enable/disable kube-scheduler leader-elect: --leader-elect=true/false

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -45,6 +45,7 @@ APISERVERS_EXTRA_NUM=${APISERVERS_EXTRA_NUM:-0}
 APISERVER_DATAPARTITION_CONFIG=${APISERVER_DATAPARTITION_CONFIG:-"abcdefghijklmnopqrstuvwxyz"}
 WORKLOADCONTROLLER_EXTRA_NUM=${WORKLOADCONTROLLER_EXTRA_NUM:-0}
 ETCD_EXTRA_NUM=${ETCD_EXTRA_NUM:-0}
+START_ETCD_GRPC_PROXY=${START_ETCD_GRPC_PROXY:-false}
 #switch to enable/disable kube-controller-manager leader-elect: --leader-elect=true/false
 ENABLE_KCM_LEADER_ELECT=${ENABLE_KCM_LEADER_ELECT:-true}
 #switch to enable/disable kube-scheduler leader-elect: --leader-elect=true/false

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -119,7 +119,13 @@ function main() {
     if [[ -z "${ETCD_SERVERS:-}" ]]; then
       start-etcd-servers
       start-etcd-empty-dir-cleanup-pod
+
+      echo "variable START_ETCD_GRPC_PROXY is ${START_ETCD_GRPC_PROXY:-}"
+      if [[ "${START_ETCD_GRPC_PROXY:-}" == "true" ]]; then
+        start-etcd-grpc-proxy
+      fi
     fi
+
     start-kube-apiserver
     start-kube-controller-manager
     start-kube-scheduler

--- a/cluster/gce/manifests/BUILD
+++ b/cluster/gce/manifests/BUILD
@@ -16,6 +16,7 @@ filegroup(
         "abac-authz-policy.jsonl",
         "cluster-autoscaler.manifest",
         "etcd.manifest",
+        "etcd-grpc-proxy.manifest",
         "etcd-empty-dir-cleanup.yaml",
         "glbc.manifest",
         "kube-addon-manager.yaml",

--- a/cluster/gce/manifests/etcd-grpc-proxy.manifest
+++ b/cluster/gce/manifests/etcd-grpc-proxy.manifest
@@ -1,0 +1,73 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {
+  "name":"etcd-grpc-proxy{{ suffix }}",
+  "namespace": "kube-system",
+  "annotations": {
+    "scheduler.alpha.kubernetes.io/critical-pod": "",
+    "seccomp.security.alpha.kubernetes.io/pod": "docker/default"
+  }
+},
+"spec":{
+"hostNetwork": true,
+"containers":[
+    {
+    "name": "etcd-grpc-proxy-container",
+    "image": "{{ pillar.get('etcd_docker_repository', 'gcr.io/{{ project_id }}/etcd-amd64') }}:{{ pillar.get('etcd_docker_tag', '3.4.3.0') }}",
+    "resources": {
+      "requests": {
+        "cpu": {{ cpulimit }}
+      }
+    },
+    "command": [
+              "/bin/sh",
+              "-c",
+              "exec /usr/local/bin/etcd grpc-proxy start --endpoints {{ etcd_protocol }}://{{ etcd_listen_client_ip }}:{{ etcd_port }} --listen-addr {{ etcd_listen_client_ip }}:{{ etcd_grpc_proxy_port }} {{ etcd_grpc_proxy_client_creds }} {{ etcd_grpc_proxy_server_creds }} 1>>/var/log/etcd-grpc-proxy{{ suffix }}.log 2>&1"
+          ],
+    "livenessProbe": {
+      "tcpSocket": {
+        "host": "127.0.0.1",
+        "port": {{  etcd_grpc_proxy_port }}
+      },
+      "initialDelaySeconds": {{ liveness_probe_initial_delay }},
+      "timeoutSeconds": 15
+    },
+    "ports": [
+      { "name": "grpcproxyport",
+        "containerPort": {{ etcd_grpc_proxy_port }},
+        "hostPort": {{ etcd_grpc_proxy_port }}
+      }
+        ],
+    "volumeMounts": [
+      { "name": "varetcd",
+        "mountPath": "/var/etcd",
+        "readOnly": false
+      },
+      { "name": "varlogetcd",
+        "mountPath": "/var/log/etcd-grpc-proxy{{ suffix }}.log",
+        "readOnly": false
+      },
+      { "name": "etc",
+        "mountPath": "/etc/srv/kubernetes",
+        "readOnly": false
+      }
+    ]
+    }
+],
+"volumes":[
+  { "name": "varetcd",
+    "hostPath": {
+        "path": "/mnt/master-pd/var/etcd"}
+  },
+  { "name": "varlogetcd",
+    "hostPath": {
+        "path": "/var/log/etcd-grpc-proxy{{ suffix }}.log",
+        "type": "FileOrCreate"}
+  },
+  { "name": "etc",
+    "hostPath": {
+        "path": "/etc/srv/kubernetes"}
+  }
+]
+}}


### PR DESCRIPTION
### Why this PR?
This PR allows perf tests to enable etcd-grpc-proxy based on the environement variables. 
If env var START_ETCD_GRPC_PROXY=true, the grpc proxy will be kicked off and the kube-apiserver will connect to the proxy port. Otherwise, kube-apiserver will talk to the etcd core server directly.

During 5k-node perf tests, we see a lot of "took too long" warnings in the core etcd server log and also many etcd delay warnings in Kube-Apiserver logs.  As the etcd grpc proxy offloads the core etcd server by coalescing the watch requests (more details are available in https://etcd.io/docs/v3.1.12/op-guide/grpc_proxy/), we tried to enable the grpc proxy to see whether it solves this issue. 


As the test run results (<em>logs can be found under GCP project: workload-controller-manager on sonya-uswest2: /home/sonyali/logs/perf-test/gce-5000/arktos/1020-qianprivate-1a0w1eshow</em>) , the proxy helps reduce the number of "took too long" warnings ( <em>the logs of the comparing run are under GCP project: workload-controller-manager on sonyadev4: /home/sonyali/logs/perf-test/gce-5000/arktos/1019-daily1019-1a0w1e</em>).

So the team decides to turn grpc proxy off be default in the continuing search for the true reason for the etcd delays, yet at the same time make this feature available within a change of env variable.

### Verification
Tested with perf-test of 100-nodes:
1. running kube-up.sh with START_ETCD_GRPC_PROXY=true. The kube-up script succeeded and the cluster was working. Verified that etcd grpc proxy was started, and kube-apiserver connected to etcd servers via the proxy port (23790）.

1. running kube-up.sh with START_ETCD_GRPC_PROXY not set. The kube-up script succeeded and the cluster was working. Verified that etcd grpc proxy was not started, and kube-apiserver connected to etcd servers via the core server port (2379）.